### PR TITLE
feat: add chat member tag field

### DIFF
--- a/chat_member.go
+++ b/chat_member.go
@@ -41,6 +41,7 @@ type ChatMemberMember struct {
 	Status    ChatMemberStatus `json:"status"`
 	User      User             `json:"user"`
 	UntilDate int              `json:"until_date,omitempty"`
+	Tag       string           `json:"tag,omitempty"`
 }
 
 // ChatMemberRestricted is a member subject to restrictions.
@@ -57,6 +58,7 @@ type ChatMemberRestricted struct {
 	CanInviteUsers        bool             `json:"can_invite_users,omitempty"`
 	CanPinMessages        bool             `json:"can_pin_messages,omitempty"`
 	UntilDate             int              `json:"until_date,omitempty"`
+	Tag                   string           `json:"tag,omitempty"`
 }
 
 // ChatMemberLeft is a user who is not and was not a member of the chat.

--- a/convert_member.go
+++ b/convert_member.go
@@ -46,9 +46,9 @@ func chatMemberFromParticipant(p tg.ChannelParticipantClass, users map[int64]*tg
 			CustomTitle:         v.Rank,
 		}
 	case *tg.ChannelParticipantSelf:
-		return &ChatMemberMember{Status: StatusMember, User: user(v.UserID)}
+		return &ChatMemberMember{Status: StatusMember, User: user(v.UserID), Tag: v.Rank}
 	case *tg.ChannelParticipant:
-		return &ChatMemberMember{Status: StatusMember, User: user(v.UserID)}
+		return &ChatMemberMember{Status: StatusMember, User: user(v.UserID), Tag: v.Rank}
 	case *tg.ChannelParticipantBanned:
 		uid := peerUserID(v.Peer)
 		if v.Left {
@@ -78,6 +78,7 @@ func chatMemberFromParticipant(p tg.ChannelParticipantClass, users map[int64]*tg
 			CanChangeInfo:         !br.ChangeInfo,
 			CanInviteUsers:        !br.InviteUsers,
 			CanPinMessages:        !br.PinMessages,
+			Tag:                   v.Rank,
 			UntilDate:             br.UntilDate,
 		}
 	case *tg.ChannelParticipantLeft:


### PR DESCRIPTION
Tag is a field for regular chat members similar to CustomTitle 

https://core.telegram.org/bots/api#chatmembermember
https://core.telegram.org/bots/api#chatmemberrestricted